### PR TITLE
Issue/long term config storing

### DIFF
--- a/System/RCB/Configuration.lhs.sample
+++ b/System/RCB/Configuration.lhs.sample
@@ -30,6 +30,11 @@ to subscribe to
 > rct_subscribe_to = ""
 
 
+Where shall the process store the current configuration for persistent
+storage?
+
+> rct_config_file = "~/.rctRssConfig"
+
 > init_string  = Con 1 1 
 > login_string = Mtd (Login 2 rct_username rct_password SHA256)
 > subscribe    = SubStreamNotifyUser 3 rct_subscribe_to

--- a/System/RCB/Plugins/RSS/Auxiliary.hs
+++ b/System/RCB/Plugins/RSS/Auxiliary.hs
@@ -18,6 +18,7 @@ import Data.RocketChat.Message.ChangedField.ChangedFieldArgs
 import System.RCB.Auxiliary
 import System.RCB.Plugins.RSS.Reader (readFeed, rss2string)
 import System.RCB.Plugins.RSS.RssConfig.Datatype
+import System.RCB.Plugins.RSS.RssConfig.FeedTransformer
 import System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
 import System.RCB.Plugins.RSS.RssConfig.PushDescriptors
 import System.RCB.Plugins.RSS.RssConfig.Modifiers

--- a/System/RCB/Plugins/RSS/Auxiliary.hs
+++ b/System/RCB/Plugins/RSS/Auxiliary.hs
@@ -11,6 +11,7 @@
 
 module System.RCB.Plugins.RSS.Auxiliary where
 
+import System.RCB.Configuration (rct_config_file)
 import Data.RocketChat.Message
 import Data.RocketChat.Message.Datatype
 import Data.RocketChat.Message.ChangedField
@@ -179,12 +180,12 @@ updateCli notify config = do
 
 store :: RssConfig -> IO ()
 store cfg = do
-  writeFile "/tmp/rssConfig.data" . show $ cfg
+  writeFile rct_config_file . show $ cfg
 
 restore :: MVar RssConfig -> IO ()
 restore config = do
   mvconf <- takeMVar config
-  readFile "/tmp/rssConfig.data" >>= putMVar config . read
+  readFile rct_config_file >>= putMVar config . read
 
 
 helpMsg :: [String]

--- a/System/RCB/Plugins/RSS/Auxiliary.hs
+++ b/System/RCB/Plugins/RSS/Auxiliary.hs
@@ -105,6 +105,18 @@ cli notify config s = do
         notify . foldl (++) "" $ helpMsg
         return False
 
+      "store" -> do
+        mvconf <- readMVar config
+        writeFile "/tmp/rssConfig.data" . show $ mvconf
+        return False
+
+      "restore" -> do
+        cfg_ <- (readFile "/tmp/rssConfig.data")
+        let cfg = (read cfg_ :: RssConfig)
+        mvconf <- takeMVar config
+        putMVar config cfg
+        return False
+
       otherwise -> do
         cfg <- readMVar config
         sequence [ grepFeeds feed fns amount >>= mapM notify | (cmd, Feed feed fns) <- feeds cfg, cmd == (head . words $ s) ]

--- a/System/RCB/Plugins/RSS/Auxiliary.hs
+++ b/System/RCB/Plugins/RSS/Auxiliary.hs
@@ -124,7 +124,6 @@ addCli config s = do
       putMVar config newconf
 
     "push" -> do
-      return ()
       mvconf <- takeMVar config
       let fn s
               | (length . words $ s) > 1 = Just ((Room ((words s)!!0) "" Direct), (words s)!!1)

--- a/System/RCB/Plugins/RSS/Auxiliary.hs
+++ b/System/RCB/Plugins/RSS/Auxiliary.hs
@@ -37,24 +37,6 @@ import Text.ParserCombinators.Parsec
 import Text.Parsec.Perm
 import Data.Text (Text, pack, unpack)
     
-grepImgUrl :: String -> String
-grepImgUrl s = fst $
-    case (parse pImageTag' "" s) of
-      Left err  -> error $ show err
-      Right xs  -> xs
-    where 
-      pImageTag' :: GenParser Char st (String, String)
-      pImageTag' = do
-        many $ noneOf "<"
-        string "<img src=\""
-        src <- manyTill anyChar (try $ string "\" title")
-        string "=\""
-        title <- manyTill anyChar (try $ string "\" alt")
-        string "=\""
-        alt <- manyTill anyChar (try $ string "\" />")
-        many anyChar
-        return (src, title)
-
 grepFeeds :: String -> FeedTransformer -> Int -> IO [String]
 grepFeeds feed ftr i = do
   xs <- readFeed i feed

--- a/System/RCB/Plugins/RSS/Auxiliary.hs
+++ b/System/RCB/Plugins/RSS/Auxiliary.hs
@@ -111,10 +111,8 @@ cli notify config s = do
         return False
 
       "restore" -> do
-        cfg_ <- (readFile "/tmp/rssConfig.data")
-        let cfg = (read cfg_ :: RssConfig)
         mvconf <- takeMVar config
-        putMVar config cfg
+        readFile "/tmp/rssConfig.data" >>= putMVar config . read
         return False
 
       otherwise -> do

--- a/System/RCB/Plugins/RSS/Auxiliary.hs
+++ b/System/RCB/Plugins/RSS/Auxiliary.hs
@@ -53,10 +53,10 @@ grepImgUrl s = fst $
         many anyChar
         return (src, title)
 
-grepFeeds :: String -> ((String -> String), (String -> String), (String -> String)) -> Int -> IO [String]
-grepFeeds feed fns i = do
+grepFeeds :: String -> FeedTransformer -> Int -> IO [String]
+grepFeeds feed ftr i = do
   xs <- readFeed i feed
-  let ms = map (rss2string fns) xs
+  let ms = map (rss2string ftr) xs
   return ms
 
 sendAndShow :: Connection -> Message -> IO ()

--- a/System/RCB/Plugins/RSS/CLI.hs
+++ b/System/RCB/Plugins/RSS/CLI.hs
@@ -32,8 +32,9 @@ process :: SF Message (Maybe (String, String))
 process =
     arr $ getText
 
-initialize :: Connection -> IO Message
-initialize c = do
+initialize :: MVar RssConfig -> Connection -> IO Message
+initialize config c = do
+    restore config
     mapM (sendAndShow c)
       [ init_string
       , login_string

--- a/System/RCB/Plugins/RSS/CLI.hs
+++ b/System/RCB/Plugins/RSS/CLI.hs
@@ -34,7 +34,6 @@ process =
 
 initialize :: MVar RssConfig -> Connection -> IO Message
 initialize config c = do
-    restore config
     mapM (sendAndShow c)
       [ init_string
       , login_string

--- a/System/RCB/Plugins/RSS/Configuration.lhs.sample
+++ b/System/RCB/Plugins/RSS/Configuration.lhs.sample
@@ -3,6 +3,7 @@
 > import System.RCB.Plugins.RSS.RssConfig.Datatype
 > import System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
 > import System.RCB.Plugins.RSS.RssConfig.PushDescriptors
+> import System.RCB.Plugins.RSS.RssConfig.FeedTransformer
 > import Data.RocketChat.Message.Datatype
 
 > import System.RCB.Plugins.RSS.Auxiliary
@@ -15,19 +16,18 @@ Here the initial definition of the feeds and feed commands:
 > rssConfig =
 >     RssConfig
 >     { feeds =
->           [ ("xkcd", Feed "https://www.xkcd.com/rss.xml" (id, id, grepImgUrl))
->           , ("fefe", Feed "https://blog.fefe.de/rss.xml?html" (filter (not . flip elem ['`', '"']), id, const ""))
->           , ("heise", Feed "http://www.heise.de/newsticker/heise.rdf" (id, id, const ""))
->           , ("golem", Feed "https://rss.golem.de/rss.php?feed=RSS2.0" (id, id, const ""))
->           , ("hackernews", Feed "https://news.ycombinator.com/rss" (id, id, const ""))
+>           [ ("xkcd", Feed "https://www.xkcd.com/rss.xml" (FeedTransformer Nothing Nothing (Just Dimgurl)))
+>           , ("fefe", Feed "https://blog.fefe.de/rss.xml?html" (FeedTransformer (Just Tdrop_quotes) Nothing (Just Dempty)))
+>           , ("heise", Feed "http://www.heise.de/newsticker/heise.rdf" (FeedTransformer Nothing Nothing (Just Dempty)))
+>           , ("golem", Feed "https://rss.golem.de/rss.php?feed=RSS2.0" (FeedTransformer Nothing Nothing (Just Dempty)))
+>           , ("hackernews", Feed "https://news.ycombinator.com/rss" (FeedTransformer Nothing Nothing (Just Dempty)))
 >           ]
 > 
 >     , pushs =
 >           Push
->             [ (Feed "https://news.ycombinator.com/rss" (id, id, const ""), [Room "frosch03" "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" Direct])
->             , (Feed "https://news.ycombinator.com/rss" (id, id, const ""), [Room "admin" "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" Direct])
->             , (Feed "https://www.xkcd.com/rss.xml" (id, id, grepImgUrl), [Room "frosch03" "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" Direct])
->             , (Feed "https://blog.fefe.de/rss.xml?html" (filter (not . flip elem ['`', '"']), id, const ""), [Room "frosch03" "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" Direct])
+>             [ (Feed "https://news.ycombinator.com/rss" (FeedTransformer Nothing Nothing (Just Dempty)), [Room "user" "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" Direct])
+>             , (Feed "https://www.xkcd.com/rss.xml" (FeedTransformer Nothing Nothing (Just Dimgurl)), [Room "user" "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" Direct])
+>             , (Feed "https://blog.fefe.de/rss.xml?html" (FeedTransformer (Just Tdrop_quotes) Nothing (Just Dempty)), [Room "user" "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" Direct])
 >             ]
 >             (6 * 60)
 >     }

--- a/System/RCB/Plugins/RSS/ITransformable.hs
+++ b/System/RCB/Plugins/RSS/ITransformable.hs
@@ -1,0 +1,20 @@
+-------------------------------------------------------------------------------
+-- | Module      :  System.RCB.Plugins.RSS.ITransformable
+--   Copyright   :  (c) Matthias Brettschneider 2019
+--   License     :  as-is
+--
+--   Maintainer  :  frosch03@gmail.com
+--   Stability   :  unstable
+--   Portability :  unportable
+--
+-------------------------------------------------------------------------------
+
+module System.RCB.Plugins.RSS.ITransformable
+where
+
+class Transformable a where
+      tfunc :: a -> String -> String
+      lfunc :: a -> String -> String
+      dfunc :: a -> String -> String
+
+

--- a/System/RCB/Plugins/RSS/Reader.hs
+++ b/System/RCB/Plugins/RSS/Reader.hs
@@ -13,6 +13,8 @@ module System.RCB.Plugins.RSS.Reader
 where
 
 import System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
+import System.RCB.Plugins.RSS.RssConfig.FeedTransformer
+import System.RCB.Plugins.RSS.ITransformable
 
 import Data.List                (isPrefixOf)
 import Data.Maybe               (catMaybes, maybeToList)

--- a/System/RCB/Plugins/RSS/Reader.hs
+++ b/System/RCB/Plugins/RSS/Reader.hs
@@ -12,6 +12,8 @@
 module System.RCB.Plugins.RSS.Reader
 where
 
+import System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
+
 import Data.List                (isPrefixOf)
 import Data.Maybe               (catMaybes, maybeToList)
 import Network.HTTP             (getResponseBody, simpleHTTP, getRequest)
@@ -32,9 +34,9 @@ data RssItem = RssItem
 
 -- | Transform the RssItem into a string that follows the rocket chat
 -- format
-rss2string :: ((String -> String), (String -> String), (String -> String)) -> RssItem -> String
-rss2string (tFn, lFn, dFn) itm =
-    "[" ++ (tFn t) ++ "](" ++ (lFn l) ++ "): " ++ (dFn d)
+rss2string :: FeedTransformer -> RssItem -> String
+rss2string ftr itm =
+    "[" ++ (tfunc ftr t) ++ "](" ++ (tfunc ftr l) ++ "): " ++ (dfunc ftr d)
     where
       t = title       itm
       l = link        itm

--- a/System/RCB/Plugins/RSS/RssConfig/Datatype.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/Datatype.hs
@@ -10,6 +10,8 @@
 -------------------------------------------------------------------------------
 
 module System.RCB.Plugins.RSS.RssConfig.Datatype
+    ( RssConfig(..)
+    )
 where
 
 import System.RCB.Plugins.RSS.RssConfig.PushDescriptors

--- a/System/RCB/Plugins/RSS/RssConfig/Datatype.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/Datatype.hs
@@ -20,5 +20,5 @@ data RssConfig
       { feeds :: [(String, FeedDescriptor)]
       , pushs :: PushDescriptors
       }
-    deriving (Show, Read)
+    deriving (Show, Read, Eq)
 

--- a/System/RCB/Plugins/RSS/RssConfig/Datatype.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/Datatype.hs
@@ -20,5 +20,5 @@ data RssConfig
       { feeds :: [(String, FeedDescriptor)]
       , pushs :: PushDescriptors
       }
-    deriving (Show)
+    deriving (Show, Read)
 

--- a/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
@@ -20,7 +20,7 @@ data FeedDescriptor
       { feedUrl         :: String
       , feedTransformer :: FeedTransformer
       }
-    deriving (Show, Read)
+    deriving (Show, Read, Eq)
 
 
 -- Defaults

--- a/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
@@ -12,7 +12,7 @@
 module System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
 where    
 
-import Text.ParserCombinators.Parsec
+import System.RCB.Plugins.RSS.RssConfig.FeedTransformer
 
 -- Datatype
 data FeedDescriptor
@@ -28,58 +28,3 @@ instance Show (FeedDescriptor) where
 -- Defaults
 defaultFeed :: FeedDescriptor
 defaultFeed = Feed "" (FeedTransformer Nothing Nothing (Just Dempty))
-  
-data TTitle
-    = Tempty
-    | Tdrop_quotes
-
-data TLink
-    = Lempty
-
-data TDescription
-    = Dempty
-    | Dimgurl
-
-class Transformable a where
-      tfunc :: a -> String -> String
-      lfunc :: a -> String -> String
-      dfunc :: a -> String -> String
-
-
-data FeedTransformer
-    = FeedTransformer
-      { feedTransformer_title :: Maybe TTitle
-      , feedTransformer_link :: Maybe TLink
-      , feedTransformer_description :: Maybe TDescription
-      }
-
-instance Transformable FeedTransformer where
-    tfunc (FeedTransformer (Just Tempty) _ _) = const ""
-    tfunc (FeedTransformer (Just Tdrop_quotes) _ _) = filter (not . flip elem ['`', '"'])
-    tfunc (FeedTransformer Nothing _ _) = id
-
-    lfunc (FeedTransformer _ (Just Lempty) _) = const ""
-    lfunc (FeedTransformer _ Nothing _) = id
-
-    dfunc (FeedTransformer _ _ (Just Dempty)) = const ""
-    dfunc (FeedTransformer _ _ (Just Dimgurl)) = grepImgUrl_local
-    dfunc (FeedTransformer _ _ Nothing) = id
-
-
-grepImgUrl_local :: String -> String
-grepImgUrl_local s = fst $
-    case (parse pImageTag' "" s) of
-      Left err  -> error $ show err
-      Right xs  -> xs
-    where
-      pImageTag' :: GenParser Char st (String, String)
-      pImageTag' = do
-        many $ noneOf "<"
-        string "<img src=\""
-        src <- manyTill anyChar (try $ string "\" title")
-        string "=\""
-        title <- manyTill anyChar (try $ string "\" alt")
-        string "=\""
-        alt <- manyTill anyChar (try $ string "\" />")
-        many anyChar
-        return (src, title)

--- a/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
@@ -20,10 +20,8 @@ data FeedDescriptor
       { feedUrl         :: String
       , feedTransformer :: FeedTransformer
       }
+    deriving (Show, Read)
 
--- Instances
-instance Show (FeedDescriptor) where
-    show (Feed url _) = url
 
 -- Defaults
 defaultFeed :: FeedDescriptor

--- a/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedDescriptor.hs
@@ -12,11 +12,13 @@
 module System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
 where    
 
+import Text.ParserCombinators.Parsec
+
 -- Datatype
 data FeedDescriptor
     = Feed
       { feedUrl         :: String
-      , feedTransformer :: (String -> String, String -> String, String -> String)
+      , feedTransformer :: FeedTransformer
       }
 
 -- Instances
@@ -25,5 +27,59 @@ instance Show (FeedDescriptor) where
 
 -- Defaults
 defaultFeed :: FeedDescriptor
-defaultFeed = Feed "" (id, id, const "")          
+defaultFeed = Feed "" (FeedTransformer Nothing Nothing (Just Dempty))
   
+data TTitle
+    = Tempty
+    | Tdrop_quotes
+
+data TLink
+    = Lempty
+
+data TDescription
+    = Dempty
+    | Dimgurl
+
+class Transformable a where
+      tfunc :: a -> String -> String
+      lfunc :: a -> String -> String
+      dfunc :: a -> String -> String
+
+
+data FeedTransformer
+    = FeedTransformer
+      { feedTransformer_title :: Maybe TTitle
+      , feedTransformer_link :: Maybe TLink
+      , feedTransformer_description :: Maybe TDescription
+      }
+
+instance Transformable FeedTransformer where
+    tfunc (FeedTransformer (Just Tempty) _ _) = const ""
+    tfunc (FeedTransformer (Just Tdrop_quotes) _ _) = filter (not . flip elem ['`', '"'])
+    tfunc (FeedTransformer Nothing _ _) = id
+
+    lfunc (FeedTransformer _ (Just Lempty) _) = const ""
+    lfunc (FeedTransformer _ Nothing _) = id
+
+    dfunc (FeedTransformer _ _ (Just Dempty)) = const ""
+    dfunc (FeedTransformer _ _ (Just Dimgurl)) = grepImgUrl_local
+    dfunc (FeedTransformer _ _ Nothing) = id
+
+
+grepImgUrl_local :: String -> String
+grepImgUrl_local s = fst $
+    case (parse pImageTag' "" s) of
+      Left err  -> error $ show err
+      Right xs  -> xs
+    where
+      pImageTag' :: GenParser Char st (String, String)
+      pImageTag' = do
+        many $ noneOf "<"
+        string "<img src=\""
+        src <- manyTill anyChar (try $ string "\" title")
+        string "=\""
+        title <- manyTill anyChar (try $ string "\" alt")
+        string "=\""
+        alt <- manyTill anyChar (try $ string "\" />")
+        many anyChar
+        return (src, title)

--- a/System/RCB/Plugins/RSS/RssConfig/FeedTransformer.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedTransformer.hs
@@ -1,0 +1,21 @@
+-------------------------------------------------------------------------------
+-- | Module      :  System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
+--   Copyright   :  (c) Matthias Brettschneider 2019
+--   License     :  as-is
+--
+--   Maintainer  :  frosch03@gmail.com
+--   Stability   :  unstable
+--   Portability :  unportable
+--
+-------------------------------------------------------------------------------
+
+module System.RCB.Plugins.RSS.RssConfig.FeedTransformer
+    ( FeedTransformer(..)
+    , TTitle(..)
+    , TLink(..)
+    , TDescription(..)
+    )
+where
+
+import System.RCB.Plugins.RSS.RssConfig.FeedTransformer.Datatype
+import System.RCB.Plugins.RSS.RssConfig.FeedTransformer.Instances

--- a/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Datatype.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Datatype.hs
@@ -1,0 +1,35 @@
+-------------------------------------------------------------------------------
+-- | Module      :  System.RCB.Plugins.RSS.RssConfig.FeedTransformer.Datatype
+--   Copyright   :  (c) Matthias Brettschneider 2019
+--   License     :  as-is
+--
+--   Maintainer  :  frosch03@gmail.com
+--   Stability   :  unstable
+--   Portability :  unportable
+--
+-------------------------------------------------------------------------------
+
+module System.RCB.Plugins.RSS.RssConfig.FeedTransformer.Datatype
+where
+
+data TTitle
+    = Tempty
+    | Tdrop_quotes
+    deriving (Show, Read)
+
+data TLink
+    = Lempty
+    deriving (Show, Read)
+
+data TDescription
+    = Dempty
+    | Dimgurl
+    deriving (Show, Read)
+
+data FeedTransformer
+    = FeedTransformer
+      { feedTransformer_title :: Maybe TTitle
+      , feedTransformer_link :: Maybe TLink
+      , feedTransformer_description :: Maybe TDescription
+      }
+    deriving (Show, Read)

--- a/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Datatype.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Datatype.hs
@@ -15,16 +15,16 @@ where
 data TTitle
     = Tempty
     | Tdrop_quotes
-    deriving (Show, Read)
+    deriving (Show, Read, Eq)
 
 data TLink
     = Lempty
-    deriving (Show, Read)
+    deriving (Show, Read, Eq)
 
 data TDescription
     = Dempty
     | Dimgurl
-    deriving (Show, Read)
+    deriving (Show, Read, Eq)
 
 data FeedTransformer
     = FeedTransformer
@@ -32,4 +32,4 @@ data FeedTransformer
       , feedTransformer_link :: Maybe TLink
       , feedTransformer_description :: Maybe TDescription
       }
-    deriving (Show, Read)
+    deriving (Show, Read, Eq)

--- a/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Instances.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Instances.hs
@@ -1,0 +1,52 @@
+-------------------------------------------------------------------------------
+-- | Module      :  System.RCB.Plugins.RSS.RssConfig.FeedTransformer.Instances
+--   Copyright   :  (c) Matthias Brettschneider 2019
+--   License     :  as-is
+--
+--   Maintainer  :  frosch03@gmail.com
+--   Stability   :  unstable
+--   Portability :  unportable
+--
+-------------------------------------------------------------------------------
+
+module System.RCB.Plugins.RSS.RssConfig.FeedTransformer.Instances
+where
+
+import System.RCB.Plugins.RSS.RssConfig.FeedTransformer.Datatype
+import System.RCB.Plugins.RSS.ITransformable
+
+import Text.ParserCombinators.Parsec
+
+
+instance Transformable FeedTransformer where
+    tfunc (FeedTransformer (Just Tempty) _ _) = const ""
+    tfunc (FeedTransformer (Just Tdrop_quotes) _ _) = filter (not . flip elem ['`', '"'])
+    tfunc (FeedTransformer Nothing _ _) = id
+
+    lfunc (FeedTransformer _ (Just Lempty) _) = const ""
+    lfunc (FeedTransformer _ Nothing _) = id
+
+    dfunc (FeedTransformer _ _ (Just Dempty)) = const ""
+    dfunc (FeedTransformer _ _ (Just Dimgurl)) = grepImgUrl_local
+    dfunc (FeedTransformer _ _ Nothing) = id
+
+
+
+grepImgUrl_local :: String -> String
+grepImgUrl_local s = fst $
+    case (parse pImageTag' "" s) of
+      Left err  -> error $ show err
+      Right xs  -> xs
+    where
+      pImageTag' :: GenParser Char st (String, String)
+      pImageTag' = do
+        many $ noneOf "<"
+        string "<img src=\""
+        src <- manyTill anyChar (try $ string "\" title")
+        string "=\""
+        title <- manyTill anyChar (try $ string "\" alt")
+        string "=\""
+        alt <- manyTill anyChar (try $ string "\" />")
+        many anyChar
+        return (src, title)
+                                          

--- a/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Instances.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/FeedTransformer/Instances.hs
@@ -27,13 +27,13 @@ instance Transformable FeedTransformer where
     lfunc (FeedTransformer _ Nothing _) = id
 
     dfunc (FeedTransformer _ _ (Just Dempty)) = const ""
-    dfunc (FeedTransformer _ _ (Just Dimgurl)) = grepImgUrl_local
+    dfunc (FeedTransformer _ _ (Just Dimgurl)) = grepImgUrl
     dfunc (FeedTransformer _ _ Nothing) = id
 
 
 
-grepImgUrl_local :: String -> String
-grepImgUrl_local s = fst $
+grepImgUrl :: String -> String
+grepImgUrl s = fst $
     case (parse pImageTag' "" s) of
       Left err  -> error $ show err
       Right xs  -> xs

--- a/System/RCB/Plugins/RSS/RssConfig/Modifiers.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/Modifiers.hs
@@ -15,6 +15,7 @@ where
 import System.RCB.Plugins.RSS.RssConfig.Datatype
 import System.RCB.Plugins.RSS.RssConfig.PushDescriptors
 import System.RCB.Plugins.RSS.RssConfig.FeedDescriptor
+import System.RCB.Plugins.RSS.RssConfig.FeedTransformer
 
 import Data.List (groupBy, group, sort)
 import Data.Maybe (listToMaybe, maybe)

--- a/System/RCB/Plugins/RSS/RssConfig/Modifiers.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/Modifiers.hs
@@ -61,7 +61,7 @@ delPushToRoom config i =
       pushs_cntexp = (concat [ map ((,) (url, fns)) rooms | (Feed url fns, rooms) <- pushList ])
       pushs_cegrp  = groupBy (\((x, _), _) ((y, _), _) -> x == y) pushs_cntexp
       pushs_cegrp' = (take (i - 1) pushs_cegrp ++ drop i pushs_cegrp)
-      pushs' =  map (foldl (\(_, brooms) (a, aroom) -> (uncurry Feed a, (aroom:brooms))) (Feed "" (id, id, id), []))
+      pushs' =  map (foldl (\(_, brooms) (a, aroom) -> (uncurry Feed a, (aroom:brooms))) (Feed "" (FeedTransformer Nothing Nothing Nothing), []))
                     pushs_cegrp'
 
 updateRooms :: RssConfig -> [(String, String)] -> RssConfig
@@ -78,7 +78,7 @@ updateRooms config rtoid =
           = cur:news
       pushs_ceupd = foldr fn [] pushs_cntexp
       pushs_cegrp  = groupBy (\((x, _), _) ((y, _), _) -> x == y) pushs_ceupd
-      pushs' =  map (foldl (\(_, brooms) (a, aroom) -> (uncurry Feed a, (aroom:brooms))) (Feed "" (id, id, id), []))
+      pushs' =  map (foldl (\(_, brooms) (a, aroom) -> (uncurry Feed a, (aroom:brooms))) (Feed "" (FeedTransformer Nothing Nothing Nothing), []))
                     pushs_cegrp
 
 

--- a/System/RCB/Plugins/RSS/RssConfig/PushDescriptors.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/PushDescriptors.hs
@@ -20,7 +20,7 @@ data PushDescriptors
       { pushFeedIntoRoomss :: [(FeedDescriptor, [Room])]
       , pushInterval       :: Int
       }
-    deriving (Show)
+    deriving (Show, Read)
 
 -- Sub-Datatype
 data Room
@@ -29,7 +29,7 @@ data Room
       , room_id   :: String
       , room_type :: RoomType
       }
-    deriving (Show, Eq, Ord)
+    deriving (Show, Read, Eq, Ord)
 
 -- SubSub-Datatype
 data RoomType = Direct | Group deriving (Show, Read, Eq, Ord)

--- a/System/RCB/Plugins/RSS/RssConfig/PushDescriptors.hs
+++ b/System/RCB/Plugins/RSS/RssConfig/PushDescriptors.hs
@@ -20,7 +20,7 @@ data PushDescriptors
       { pushFeedIntoRoomss :: [(FeedDescriptor, [Room])]
       , pushInterval       :: Int
       }
-    deriving (Show, Read)
+    deriving (Show, Read, Eq)
 
 -- Sub-Datatype
 data Room

--- a/System/RCB/RCB.hs
+++ b/System/RCB/RCB.hs
@@ -44,7 +44,7 @@ reactiveWS c = do
       reactimate (PUSH.initialize config c) (PUSH.sense config c) (PUSH.actuate c) PUSH.process
 
   putStrLn "Starting Rss Commands"
-  reactimate (CLI.initialize c) (CLI.sense c) (CLI.actuate config c) CLI.process
+  reactimate (CLI.initialize config c) (CLI.sense c) (CLI.actuate config c) CLI.process
 
 main :: IO ()
 main = runSecureClient rct_server rct_port rct_path reactiveWS


### PR DESCRIPTION
Done via refactoring of the `RssConfig` data type. There are no longer functions directly within the configuration. But a data type captures the things one shall be able to do with title, link and description from an rss feed. 

After that refactor, simply deriving `Read` and `Show` for all that types enables one to just store a string into a file. This is done by the RCT. 